### PR TITLE
Fix Vibe unittests

### DIFF
--- a/src/temple/vibe.d
+++ b/src/temple/vibe.d
@@ -50,7 +50,7 @@ void renderTemple(string temple, Ctx = TempleContext)
 {
 	mixin(SetupContext);
 
-	auto t = Temple!(temple, TempleHtmlFilter);
+	auto t = compile_temple!(temple, TempleHtmlFilter);
 	t.render(res.bodyWriter, context);
 }
 


### PR DESCRIPTION
This fixes the Vibe unittests, using createTestHTTPServerResponse. Also fixes a deprecation warning caused by renderTemple.