### PR TITLE
Fix compile errors when using TempleContext with Vibe

### DIFF
--- a/src/temple/vibe.d
+++ b/src/temple/vibe.d
@@ -9,6 +9,7 @@ private {
 	import vibe.http.server;
 	import vibe.textfilter.html;
 	import std.stdio;
+	import std.variant;
 }
 
 struct TempleHtmlFilter {
@@ -21,12 +22,20 @@ struct TempleHtmlFilter {
 		filterHTMLEscape(stream, unsafe);
 	}
 
+	static void temple_filter(ref TempleOutputStream stream, Variant variant) {
+		temple_filter(stream, variant.toString);
+	}
+
 	static string temple_filter(SafeString safe) {
 		return safe.payload;
 	}
 
 	static SafeString safe(string str) {
 		return SafeString(str);
+	}
+
+	static SafeString safe(Variant variant) {
+		return SafeString(variant.toString);
 	}
 }
 


### PR DESCRIPTION
Fixes `Error: static assert  "Filter does not have a case that accepts a VariantN!32LU"` when trying to use context variables with Vibe. Also some minor style fixes from my last PR.