### PR TITLE
Fix vibe.d v0.7.27 Type Change

### DIFF
--- a/src/temple/vibe.d
+++ b/src/temple/vibe.d
@@ -8,6 +8,7 @@ private {
 	import temple;
 	import vibe.http.server;
 	import vibe.textfilter.html;
+	import vibe.utils.dictionarylist;
 	import std.stdio;
 	import std.variant;
 }
@@ -86,9 +87,13 @@ void renderTempleLayoutFile(string layout_file, string partial_file, Ctx = Templ
 }
 
 private void copyContextParams(ref TempleContext ctx, ref HTTPServerRequest req) {
-
-	if(!req || !(req.params))
-		return;
+	static if(is(typeof(req.params) == string[string])) {
+		if(!req || !(req.params))
+			return;
+	} else if(is(typeof(req.params) == DictionaryList!(string, true, 32))) {
+		if(!req || req.params.length < 1)
+			return;
+	}
 
 	foreach(key, val; req.params) {
 		ctx[key] = val;


### PR DESCRIPTION
Fixed a bug with vibe.d integration where the parameters type changed from `string[string]` to `DictionaryList`.

Over in [vibe.d](https://github.com/rejectedsoftware/vibe.d) the params are right [here](https://github.com/rejectedsoftware/vibe.d/blob/5415eeb60973eec78a70c37e0633798a0a085539/source/vibe/http/server.d#L621).

This should compile whether an old version of vibe.d is used or whether the latest [v0.7.27](https://github.com/rejectedsoftware/vibe.d/releases/tag/v0.7.27) version is used.

Let me know if you want to change anything. :sunglasses: 

