### PR TITLE
Fix deprecation warning and broken import

### DIFF
--- a/src/temple/func_string_gen.d
+++ b/src/temple/func_string_gen.d
@@ -420,7 +420,8 @@ string build_function_head(string filter_ident) {
 		ret ~= `
 	void __temple_buff_filtered_put(T)(T thing)
 	{
-		__temple_context.put(.std.conv.to!string(thing));
+		import std.conv : to;
+		__temple_context.put(to!string(thing));
 	}
 
 	/// without filter, render subtemplate with an explicit context (which defaults to null)

--- a/src/temple/package.d
+++ b/src/temple/package.d
@@ -26,6 +26,7 @@ private import
 private import std.array : appender, Appender;
 private import std.range : isOutputRange;
 private import std.typecons : scoped;
+private import std.stdio : File;
 
 public {
     import temple.temple_context : TempleContext;
@@ -165,7 +166,7 @@ public:
     void render(void function(string) sink, TempleContext tc = null) const {
     	auto oc = TempleOutputStream(sink);
     	this.render(oc, tc); }
-    void render(ref std.stdio.File f, TempleContext tc = null) const {
+    void render(ref File f, TempleContext tc = null) const {
         auto oc = TempleOutputStream(f);
         this.render(oc, tc);
     }


### PR DESCRIPTION
- fix use of std.conv.to which was not imported in the file
- added a local import
- tested that the mixed in code compiles
